### PR TITLE
fix: calculator layout

### DIFF
--- a/app/src/main/res/layout/activity_calculator.xml
+++ b/app/src/main/res/layout/activity_calculator.xml
@@ -5,19 +5,22 @@
     android:orientation="vertical">
 
     <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content">
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
 
         <Spinner
             android:id="@+id/spinb"
-            android:layout_width="160dp"
+            android:layout_width="0dp"
+            android:layout_weight="1"
             android:layout_height="50dp"
             android:layout_marginLeft="20dp"
             android:layout_marginTop="15dp" />
 
         <Spinner
             android:id="@+id/spins"
-            android:layout_width="160dp"
+            android:layout_width="0dp"
+            android:layout_weight="1"
             android:layout_height="50dp"
             android:layout_marginLeft="20dp"
             android:layout_marginTop="15dp" />
@@ -35,45 +38,52 @@
 
 
     <ScrollView
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="20dp">
+        android:layout_marginLeft="20dp"
+        android:layout_marginRight="20dp">
 
         <LinearLayout
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
             <LinearLayout
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content">
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:weightSum="9">
 
                 <TextView
                     android:id="@+id/tv1"
-                    android:layout_width="60dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="2"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="20dp"
                     android:layout_marginTop="18dp"
-
                     android:text="TH 1"
                     android:textColor="#01b29b"
                     android:textSize="20dp" />
 
                 <EditText
                     android:id="@+id/one"
-                    android:layout_width="70dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="2"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="2dp"
                     android:layout_marginTop="12dp"
                     android:gravity="bottom|center"
                     android:inputType="number"
                     android:textSize="15dp" />
 
+                <View
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"/>
+
                 <TextView
                     android:id="@+id/tv6"
-                    android:layout_width="60dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="2"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="50dp"
                     android:layout_marginTop="18dp"
 
                     android:text="PR 1"
@@ -82,9 +92,9 @@
 
                 <EditText
                     android:id="@+id/six"
-                    android:layout_width="70dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="2"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="2dp"
                     android:layout_marginTop="12dp"
                     android:gravity="bottom|center"
                     android:phoneNumber="true"
@@ -93,14 +103,15 @@
             </LinearLayout>
 
             <LinearLayout
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content">
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:weightSum="9">
 
                 <TextView
                     android:id="@+id/tv2"
-                    android:layout_width="60dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="2"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="20dp"
                     android:layout_marginTop="18dp"
 
                     android:text="TH 2"
@@ -109,19 +120,24 @@
 
                 <EditText
                     android:id="@+id/two"
-                    android:layout_width="70dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="2"
                     android:layout_height="wrap_content"
                     android:layout_marginLeft="2dp"
                     android:layout_marginTop="12dp"
                     android:gravity="bottom|center"
                     android:inputType="number"
                     android:textSize="15dp" />
+                <View
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"/>
 
                 <TextView
                     android:id="@+id/tv7"
-                    android:layout_width="60dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="2"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="50dp"
                     android:layout_marginTop="18dp"
 
                     android:text="PR 2"
@@ -130,7 +146,8 @@
 
                 <EditText
                     android:id="@+id/seven"
-                    android:layout_width="70dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="2"
                     android:layout_height="wrap_content"
                     android:layout_marginLeft="2dp"
                     android:layout_marginTop="12dp"
@@ -142,13 +159,14 @@
 
             <LinearLayout
                 android:layout_width="fill_parent"
-                android:layout_height="wrap_content">
+                android:layout_height="wrap_content"
+                android:weightSum="9">
 
                 <TextView
                     android:id="@+id/tv3"
-                    android:layout_width="60dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="2"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="20dp"
                     android:layout_marginTop="18dp"
 
                     android:text="TH 3"
@@ -157,19 +175,23 @@
 
                 <EditText
                     android:id="@+id/three"
-                    android:layout_width="70dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="2"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="2dp"
                     android:layout_marginTop="12dp"
                     android:gravity="bottom|center"
                     android:inputType="number"
                     android:textSize="15sp" />
+                <View
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"/>
 
                 <TextView
                     android:id="@+id/tv8"
-                    android:layout_width="60dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="2"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="50dp"
                     android:layout_marginTop="18dp"
 
                     android:text="PR 3"
@@ -178,9 +200,9 @@
 
                 <EditText
                     android:id="@+id/eight"
-                    android:layout_width="70dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="2"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="2dp"
                     android:layout_marginTop="12dp"
                     android:gravity="bottom|center"
                     android:inputType="number"
@@ -190,13 +212,14 @@
 
             <LinearLayout
                 android:layout_width="fill_parent"
-                android:layout_height="wrap_content">
+                android:layout_height="wrap_content"
+                android:weightSum="9">
 
                 <TextView
                     android:id="@+id/tv4"
-                    android:layout_width="60dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="2"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="20dp"
                     android:layout_marginTop="18dp"
 
                     android:text="TH 4"
@@ -205,19 +228,24 @@
 
                 <EditText
                     android:id="@+id/four"
-                    android:layout_width="70dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="2"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="2dp"
                     android:layout_marginTop="12dp"
                     android:gravity="bottom|center"
                     android:inputType="number"
                     android:textSize="15dp" />
 
+                <View
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"/>
+
                 <TextView
                     android:id="@+id/tv9"
-                    android:layout_width="60dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="2"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="50dp"
                     android:layout_marginTop="18dp"
 
                     android:text="PR 4"
@@ -226,9 +254,9 @@
 
                 <EditText
                     android:id="@+id/nine"
-                    android:layout_width="70dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="2"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="2dp"
                     android:layout_marginTop="12dp"
                     android:gravity="bottom|center"
                     android:inputType="number"
@@ -237,14 +265,15 @@
             </LinearLayout>
 
             <LinearLayout
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content">
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:weightSum="9">
 
                 <TextView
                     android:id="@+id/tv5"
-                    android:layout_width="60dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="2"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="20dp"
                     android:layout_marginTop="18dp"
 
                     android:text="TH 5"
@@ -253,19 +282,24 @@
 
                 <EditText
                     android:id="@+id/five"
-                    android:layout_width="70dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="2"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="2dp"
                     android:layout_marginTop="12dp"
                     android:gravity="bottom|center"
                     android:inputType="number"
                     android:textSize="15dp" />
 
+                <View
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"/>
+
                 <TextView
                     android:id="@+id/tv10"
-                    android:layout_width="60dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="2"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="50dp"
                     android:layout_marginTop="18dp"
 
                     android:text="PR 5"
@@ -274,9 +308,9 @@
 
                 <EditText
                     android:id="@+id/ten"
-                    android:layout_width="70dp"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="2dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="2"
                     android:layout_marginTop="12dp"
                     android:gravity="bottom|center"
                     android:inputType="number"
@@ -285,14 +319,15 @@
             </LinearLayout>
 
             <LinearLayout
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content">
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:weightSum="9">
 
                 <TextView
                     android:id="@+id/tv12"
-                    android:layout_width="60dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="2"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="20dp"
                     android:layout_marginTop="18dp"
 
                     android:text="VS 2"
@@ -301,19 +336,24 @@
 
                 <EditText
                     android:id="@+id/twelve"
-                    android:layout_width="70dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="2"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="2dp"
                     android:layout_marginTop="12dp"
                     android:gravity="bottom|center"
                     android:inputType="number"
                     android:textSize="15dp" />
 
+                <View
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"/>
+
                 <TextView
                     android:id="@+id/tv11"
-                    android:layout_width="60dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="2"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="50dp"
                     android:layout_marginTop="18dp"
 
                     android:text="VS 1"
@@ -322,9 +362,9 @@
 
                 <EditText
                     android:id="@+id/eleven"
-                    android:layout_width="70dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="2"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="2dp"
                     android:layout_marginTop="12dp"
                     android:gravity="bottom|center"
                     android:inputType="number"
@@ -333,56 +373,75 @@
             </LinearLayout>
 
             <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content">
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="20dp"
+                android:layout_marginRight="20dp"
+                android:orientation="horizontal"
+                android:weightSum="9">
 
                 <Button
                     android:id="@+id/button"
                     style="?android:attr/buttonStyleSmall"
-                    android:layout_width="125dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="4"
                     android:layout_height="50dp"
-                    android:layout_marginLeft="20dp"
                     android:layout_marginTop="15dp"
                     android:background="@color/colorPrimary"
                     android:clickable="true"
                     android:onClick="onSub"
                     android:text="View Subjects"
                     android:textColor="#ffffff"
-                    android:textSize="15dp" />
+                    android:textSize="15dp"
+                    android:padding="5dp"/>
+
+                <View
+                    android:layout_width="0dp"
+                    android:layout_weight="1"
+                    android:layout_height="wrap_content"/>
 
                 <Button
                     android:id="@+id/buttC"
                     style="?android:attr/buttonStyleSmall"
-                    android:layout_width="125dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="4"
                     android:layout_height="50dp"
-                    android:layout_marginLeft="60dp"
                     android:layout_marginTop="15dp"
                     android:background="@color/colorPrimary"
                     android:clickable="true"
                     android:onClick="onCalculate"
                     android:text="Calculate"
                     android:textColor="#ffffff"
-                    android:textSize="15dp" />
+                    android:textSize="15dp"
+                    android:padding="5dp"/>
             </LinearLayout>
 
             <LinearLayout
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content">
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:weightSum="11"
+                android:gravity="right">
 
                 <TextView
                     android:id="@+id/per"
-                    android:layout_width="200dp"
+                    android:layout_width="0dp"
+                    android:layout_weight="5"
                     android:layout_height="50dp"
-                    android:layout_marginLeft="80dp"
                     android:layout_marginTop="12dp"
                     android:gravity="center_vertical|center"
                     android:text="@string/percentage"
                     android:textColor="#01b29b"
                     android:textSize="25dp" />
 
+                <View
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"/>
+
                 <TextView
                     android:id="@+id/textView11"
-                    android:layout_width="50dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="50dp"
                     android:layout_marginTop="15dp"
                     android:gravity="center|fill_vertical"


### PR DESCRIPTION
Added dynamic view measurements in activity_calculator by using linear layout weights. Hardcoded horizontal view margins were removed and replaced with a combination of viewgroup margins and weighted empty views to provide a consistent horizontally measured layout which should scale identically to most screen sizes.